### PR TITLE
Allow configuration via environment variables

### DIFF
--- a/transport/mqtt/flags.go
+++ b/transport/mqtt/flags.go
@@ -5,6 +5,8 @@ import (
 	"crypto/x509"
 	"io/ioutil"
 	"log"
+	"os"
+	"strconv"
 )
 
 // FlagStrFunc is passed to the Flags() function, it is compatible with the standard library
@@ -17,15 +19,18 @@ type FlagBoolFunc func(name string, def bool, usage string) *bool
 
 // Flags will use the provided callbacks to set up mqtt-specific cli arguments:
 //
-//  mqtt.address   (localhost:1883) - Address of server
-//  mqtt.username                   - Username
-//  mqtt.password                   - Password
-//  mqtt.tls                        - Enable TLS (bool flag)
-//    mqtt.tls-insecure             - Skip cert validation (bool flag)
-//    mqtt.cn                       - CN of server (i.e. hostname)
-//    mqtt.ca                       - Path to authority certificate
-//    mqtt.cert                     - Path to client certificate
-//    mqtt.key                      - Path to certificate key
+//  mqtt.address   (localhost:1883) - Address of server                (MQTT_ADDRESS)
+//  mqtt.username                   - Username                         (MQTT_USERNAME)
+//  mqtt.password                   - Password                         (MQTT_PASSWORD)
+//  mqtt.tls                        - Enable TLS (bool flag)           (MQTT_TLS)
+//    mqtt.tls-insecure             - Skip cert validation (bool flag) (MQTT_TLS_INSECURE)
+//    mqtt.cn                       - CN of server (i.e. hostname)     (MQTT_COMMON_NAME)
+//    mqtt.ca                       - Path to authority certificate    (MQTT_CA_PATH)
+//    mqtt.cert                     - Path to client certificate       (MQTT_CERT_PATH)
+//    mqtt.key                      - Path to certificate key          (MQTT_KEY_PATH)
+//  topic.announce                  - Topic for announcements          (HEMTJANST_TOPIC_ANNOUNCE)
+//  topic.discover                  - Topic for discovery              (HEMTJANST_TOPIC_DISCOVER)
+//  topic.leave                     - Topic for leaving                (HEMTJANST_TOPIC_LEAVE)
 //
 // The callback interfaces are compatible with the standard library flag-package.
 // If using the flag-package, you can easily set up the mqtt transport with CLI flags
@@ -41,26 +46,57 @@ type FlagBoolFunc func(name string, def bool, usage string) *bool
 //  )
 //  func main() {
 //    myCustomFlag := flag.String("custom", "", "Set up your own flags here")
-//    mqtt.Flags(flag.String, flag.Bool)
+//    mqCfg := mqtt.MustFlags(flag.String, flag.Bool)
 //    flag.Parse()
-//    transport, err := mqtt.New(context.TODO(), "")
+//    transport, err := mqtt.New(context.TODO(), mqCfg())
 //  }
 func Flags(str FlagStrFunc, b FlagBoolFunc) func() (*Config, error) {
 	if str == nil || b == nil {
 		return nil
 	}
-	flagAddress := str("mqtt.address", "localhost:1883", "Address to MQTT endpoint")
-	flagUsername := str("mqtt.username", "", "MQTT Username")
-	flagPassword := str("mqtt.password", "", "MQTT Password")
-	flagTLS := b("mqtt.tls", false, "Enable TLS")
-	flagTLSInsecure := b("mqtt.tls-insecure", false, "Disable TLS certificate validation")
-	flagTLSHostname := str("mqtt.cn", "", "Common name of server certificate (usually the hostname)")
-	flagCaPath := str("mqtt.ca", "", "Path to CA certificate")
-	flagCertPath := str("mqtt.cert", "", "Path to Client certificate")
-	flagKeyPath := str("mqtt.key", "", "Path to Client certificate key")
-	flagAnnounceTopic := str("topic.announce", "announce", "Announce topic for Hemtjänst")
-	flagDiscoverTopic := str("topic.discover", "discover", "Discover topic for Hemtjänst")
-	flagLeaveTopic := str("topic.leave", "leave", "Leave topic for hemtjänst")
+
+	envAddr := os.Getenv("MQTT_ADDRESS")
+	if envAddr == "" {
+		envAddr = "localhost:1883"
+	}
+	envDiscoverTopic := os.Getenv("HEMTJANST_TOPIC_DISCOVER")
+	if envDiscoverTopic == "" {
+		envDiscoverTopic = "discover"
+	}
+	envAnnounceTopic := os.Getenv("HEMTJANST_TOPIC_ANNOUNCE")
+	if envAnnounceTopic == "" {
+		envAnnounceTopic = "announce"
+	}
+	envLeaveTopic := os.Getenv("HEMTJANST_TOPIC_LEAVE")
+	if envLeaveTopic == "" {
+		envLeaveTopic = "leave"
+	}
+	var envPwd string
+	if os.Getenv("MQTT_PASSWORD") != "" {
+		// Mask environment password in --help
+		envPwd = "**********"
+	}
+
+	envUsername := os.Getenv("MQTT_USERNAME")
+	envCommonName := os.Getenv("MQTT_COMMON_NAME")
+	envCaPath := os.Getenv("MQTT_CA_PATH")
+	envCertPath := os.Getenv("MQTT_CERT_PATH")
+	envKeyPath := os.Getenv("MQTT_KEY_PATH")
+	envTls, _ := strconv.ParseBool(os.Getenv("MQTT_TLS"))
+	envTlsInsecure, _ := strconv.ParseBool(os.Getenv("MQTT_TLS_INSECURE"))
+
+	flagAddress := str("mqtt.address", envAddr, "Address to MQTT endpoint")
+	flagUsername := str("mqtt.username", envUsername, "MQTT Username")
+	flagPassword := str("mqtt.password", envPwd, "MQTT Password")
+	flagTLS := b("mqtt.tls", envTls, "Enable TLS")
+	flagTLSInsecure := b("mqtt.tls-insecure", envTlsInsecure, "Disable TLS certificate validation")
+	flagTLSHostname := str("mqtt.cn", envCommonName, "Common name of server certificate (usually the hostname)")
+	flagCaPath := str("mqtt.ca", envCaPath, "Path to CA certificate")
+	flagCertPath := str("mqtt.cert", envCertPath, "Path to Client certificate")
+	flagKeyPath := str("mqtt.key", envKeyPath, "Path to Client certificate key")
+	flagAnnounceTopic := str("topic.announce", envAnnounceTopic, "Announce topic for Hemtjänst")
+	flagDiscoverTopic := str("topic.discover", envDiscoverTopic, "Discover topic for Hemtjänst")
+	flagLeaveTopic := str("topic.leave", envLeaveTopic, "Leave topic for hemtjänst")
 
 	return func() (c *Config, err error) {
 		c = &Config{}
@@ -72,8 +108,15 @@ func Flags(str FlagStrFunc, b FlagBoolFunc) func() (*Config, error) {
 			c.Username = *flagUsername
 		}
 		if flagPassword != nil && *flagPassword != "" {
-			c.Password = *flagPassword
+			if envPwd != "" && *flagPassword == envPwd {
+				// Revert to using the environment if no other password
+				// was set via flags
+				c.Password = os.Getenv("MQTT_PASSWORD")
+			} else {
+				c.Password = *flagPassword
+			}
 		}
+
 		if flagTLS != nil && *flagTLS {
 			skipVerify := false
 			certFile := ""


### PR DESCRIPTION
Add support for configuring via environment variables (using the default field of the flags).

Command line arguments will override anything set by environment

Available variables:
* `MQTT_ADDRESS`
* `HEMTJANST_TOPIC_DISCOVER`
* `HEMTJANST_TOPIC_ANNOUNCE`
* `HEMTJANST_TOPIC_LEAVE`
* `MQTT_PASSWORD`
* `MQTT_USERNAME`
* `MQTT_COMMON_NAME`
* `MQTT_CA_PATH`
* `MQTT_CERT_PATH`
* `MQTT_KEY_PATH`
* `MQTT_TLS`
* `MQTT_TLS_INSECURE`