### PR TITLE
Make mqtt runtime error detection possible

### DIFF
--- a/transport/mqtt/interface.go
+++ b/transport/mqtt/interface.go
@@ -1,8 +1,23 @@
 package mqtt
 
-import "lib.hemtjan.st/device"
+import (
+	"lib.hemtjan.st/device"
+)
 
 type MQTT interface {
+	// Start connects to mqtt and block until disconnected.
+	// "ok" is true if the client is still valid and should be reused by calling Start() again
+	//
+	// Example of running with reconnect:
+	//   for {
+	//     ok, err := client.Start(ctx)
+	//     if !ok {
+	//       break
+	//     }
+	//     log.Printf("Error %v - retrying in 5 seconds", err)
+	//     time.Sleep(5 * time.Second)
+	//   }
+	Start() (ok bool, err error)
 	TopicName(t EventType) string
 	DeviceState() chan *device.State
 	PublishMeta(topic string, payload []byte)

--- a/transport/mqtt/libmqtt.go
+++ b/transport/mqtt/libmqtt.go
@@ -1,6 +1,9 @@
 package mqtt
 
-import "github.com/goiiot/libmqtt"
+import (
+	"fmt"
+	"github.com/goiiot/libmqtt"
+)
 
 type mqttClient interface {
 	// Connect to all specified server with client options
@@ -17,4 +20,114 @@ type mqttClient interface {
 
 	// Destroy all client connection
 	Destroy(force bool)
+}
+
+// Code is a wrapper for mqtt codes with utils for displaying the error.
+// The type does not check if the code is an error or not, it always implements the error interface for convenience
+type Code byte
+
+// Error returns the same information as String(), with the prefix "mqtt: "
+func (c Code) Error() string {
+	return "mqtt: " + c.String()
+}
+
+// String returns the same information as Text(), with the integer code appended
+func (c Code) String() string {
+	return fmt.Sprintf("%s (%d)", c.Text(), uint8(c))
+}
+
+// Text returns a textual representation of the code
+func (c Code) Text() string {
+	switch c {
+	case libmqtt.CodeSuccess: // 0 - Packet: ConnAck, PubAck, PubRecv, PubRel, PubComp, UnSubAck, Auth
+		return "success"
+	case libmqtt.CodeGrantedQos1: // 1 - Packet: SubAck
+		return "granted QoS 1"
+	case libmqtt.CodeGrantedQos2: // 2 - Packet: SubAck
+		return "granted QoS 2"
+	case libmqtt.CodeDisconnWithWill: // 4 - Packet: DisConn
+		return "disconnected with will"
+	case libmqtt.CodeNoMatchingSubscribers: // 16 - Packet: PubAck, PubRecv
+		return "no matching subscribers"
+	case libmqtt.CodeNoSubscriptionExisted: // 17 - Packet: UnSubAck
+		return "no subscription existed"
+	case libmqtt.CodeContinueAuth: // 24 - Packet: Auth
+		return "continue auth"
+	case libmqtt.CodeReAuth: // 25 - Packet: Auth
+		return "re auth"
+	case libmqtt.CodeUnspecifiedError: // 128 - Packet: ConnAck, PubAck, PubRecv, SubAck, UnSubAck, DisConn
+		return "unspecified error"
+	case libmqtt.CodeMalformedPacket: // 129 - Packet: ConnAck, DisConn
+		return "malformed packet"
+	case libmqtt.CodeProtoError: // 130 - Packet: ConnAck, DisConn
+		return "protocol error"
+	case libmqtt.CodeImplementationSpecificError: // 131 - Packet: ConnAck, PubAck, PubRecv, SubAck, UnSubAck, DisConn
+		return "implementation specific error"
+	case libmqtt.CodeUnsupportedProtoVersion: // 132 - Packet: ConnAck
+		return "unsupported protocol version"
+	case libmqtt.CodeClientIdNotValid: // 133 - Packet: ConnAck
+		return "client id not valid"
+	case libmqtt.CodeBadUserPass: // 134 - Packet: ConnAck
+		return "bad username or password"
+	case libmqtt.CodeNotAuthorized: // 135 - Packet: ConnAck, PubAck, PubRecv, SubAck, UnSubAck, DisConn
+		return "not authorized"
+	case libmqtt.CodeServerUnavail: // 136 - Packet: ConnAck
+		return "server unavailable"
+	case libmqtt.CodeServerBusy: // 137 - Packet: ConnAck, DisConn
+		return "server busy"
+	case libmqtt.CodeBanned: // 138 - Packet: ConnAck
+		return "banned"
+	case libmqtt.CodeServerShuttingDown: // 139 - Packet: DisConn
+		return "server is shutting down"
+	case libmqtt.CodeBadAuthenticationMethod: // 140 - Packet: ConnAck, DisConn
+		return "bad authentication method"
+	case libmqtt.CodeKeepaliveTimeout: // 141 - Packet: DisConn
+		return "keepalive timeout"
+	case libmqtt.CodeSessionTakenOver: // 142 - Packet: DisConn
+		return "session taken over"
+	case libmqtt.CodeTopicFilterInvalid: // 143 - Packet: SubAck, UnSubAck, DisConn
+		return "topic filter invalid"
+	case libmqtt.CodeTopicNameInvalid: // 144 - Packet: ConnAck, PubAck, PubRecv, DisConn
+		return "topic name invalid"
+	case libmqtt.CodePacketIdentifierInUse: // 145 - Packet: PubAck, PubRecv, PubAck, UnSubAck
+		return "packet identifier in use"
+	case libmqtt.CodePacketIdentifierNotFound: // 146 - Packet: PubRel, PubComp
+		return "packet identifier not found"
+	case libmqtt.CodeReceiveMaxExceeded: // 147 - Packet: DisConn
+		return "receive max exceeded"
+	case libmqtt.CodeTopicAliasInvalid: // 148 - Packet: DisConn
+		return "topic alias invalid"
+	case libmqtt.CodePacketTooLarge: // 149 - Packet: ConnAck, DisConn
+		return "packet too large"
+	case libmqtt.CodeMessageRateTooHigh: // 150 - Packet: DisConn
+		return "message rate too high"
+	case libmqtt.CodeQuotaExceeded: // 151 - Packet: ConnAck, PubAck, PubRec, SubAck, DisConn
+		return "quota exceeded"
+	case libmqtt.CodeAdministrativeAction: // 152 - Packet: DisConn
+		return "administrative action"
+	case libmqtt.CodePayloadFormatInvalid: // 153 - Packet: ConnAck, PubAck, PubRecv, DisConn
+		return "payload format invalid"
+	case libmqtt.CodeRetainNotSupported: // 154 - Packet: ConnAck, DisConn
+		return "retain not supported"
+	case libmqtt.CodeQosNoSupported: // 155 - Packet: ConnAck, DisConn
+		return "QoS not supported"
+	case libmqtt.CodeUseAnotherServer: // 156 - Packet: ConnAck, DisConn
+		return "use another server"
+	case libmqtt.CodeServerMoved: // 157 - Packet: ConnAck, DisConn
+		return "server moved"
+	case libmqtt.CodeSharedSubscriptionNotSupported: // 158 - Packet: SubAck, DisConn
+		return "shared subscription not supported"
+	case libmqtt.CodeConnectionRateExceeded: // 159 - Packet: ConnAck, DisConn
+		return "connection rate exceeded"
+	case libmqtt.CodeMaxConnectTime: // 160 - Packet: DisConn
+		return "max connect time reached"
+	case libmqtt.CodeSubscriptionIdentifiersNotSupported: // 161 - Packet: SubAck, DisConn
+		return "subscription identifiers not supported"
+	case libmqtt.CodeWildcardSubscriptionNotSupported: // 162 - Packet: SubAck, DisConn
+		return "wildcard subscriptions not supported"
+	case 255:
+		return "network error"
+	default:
+		return "unknown"
+	}
 }

--- a/transport/mqtt/mqtt.go
+++ b/transport/mqtt/mqtt.go
@@ -2,9 +2,6 @@ package mqtt
 
 import (
 	"context"
-	"errors"
-	"fmt"
-	"log"
 	"sync"
 	"time"
 
@@ -18,7 +15,8 @@ type mqtt struct {
 	deviceState   chan *device.State
 	client        mqttClient
 	addr          string
-	initCh        chan error
+	errCh         chan error
+	stopCh        []chan struct{}
 	sub           map[string][]chan []byte
 	subRaw        map[string][]chan *Packet
 	willMap       map[string][]string
@@ -30,47 +28,25 @@ type mqtt struct {
 	announceTopic string
 	discoverTopic string
 	leaveTopic    string
+	ctx           context.Context
 	sync.RWMutex
 }
 
-func New(ctx context.Context, c *Config) (m MQTT, err error) {
+func New(ctx context.Context, c *Config) (MQTT, error) {
 	if c == nil {
 		return nil, ErrNoConfig
 	}
-	if err = c.check(); err != nil {
-		return
+	if err := c.check(); err != nil {
+		return nil, err
 	}
-	mq := &mqtt{
+	m := &mqtt{
 		discoverDelay: c.DiscoverDelay,
 		willID:        c.ClientID,
 		announceTopic: c.AnnounceTopic,
 		discoverTopic: c.DiscoverTopic,
 		leaveTopic:    c.LeaveTopic,
 		willMap:       map[string][]string{},
-	}
-	opts := []libmqtt.Option{
-		libmqtt.WithRouter(newRouter(mq)),
-	}
-	opts = append(opts, c.opts()...)
-
-	client, err := libmqtt.NewClient(opts...)
-	if err != nil {
-		m = nil
-		return
-	}
-
-	if err = mq.init(ctx, client); err != nil {
-		m = nil
-	}
-	m = mq
-	return
-}
-
-func (m *mqtt) init(ctx context.Context, client mqttClient) (err error) {
-	m.Lock()
-	if m.client != nil {
-		m.Unlock()
-		return errors.New("already initialized")
+		ctx:           ctx,
 	}
 	if m.announceTopic == "" {
 		m.announceTopic = "announce"
@@ -85,82 +61,174 @@ func (m *mqtt) init(ctx context.Context, client mqttClient) (err error) {
 		m.discoverDelay = 5 * time.Second
 	}
 
-	m.initCh = make(chan error)
-	m.sub = map[string][]chan []byte{}
-	m.subRaw = map[string][]chan *Packet{}
-	m.client = client
-	m.Unlock()
-	m.client.Connect(m.onConnect)
-	err, _ = <-m.initCh
-	m.initCh = nil
-
-	if err != nil {
-		m.client.Destroy(true)
-		return
+	opts := []libmqtt.Option{
+		libmqtt.WithRouter(newRouter(m)),
 	}
+	opts = append(opts, c.opts()...)
 
-	if ctx != nil {
+	client, err := libmqtt.NewClient(opts...)
+	if err != nil {
+		return nil, err
+	}
+	m.client = client
+
+	if ctx != nil && ctx.Done() != nil {
 		go func() {
 			<-ctx.Done()
-			m.client.Destroy(false)
-			m.Lock()
-			dsub := m.discoverSub
-			m.discoverSub = []chan struct{}{}
-			subs := m.sub
-			m.sub = map[string][]chan []byte{}
-			stateCh := m.deviceState
-			m.deviceState = nil
-			m.Unlock()
-
-			if stateCh != nil {
-				close(stateCh)
-			}
-
-			for _, ch := range dsub {
-				close(ch)
-			}
-
-			if m.subRaw != nil {
-				for _, v := range m.subRaw {
-					for _, vv := range v {
-						close(vv)
-					}
-				}
-				m.subRaw = map[string][]chan *Packet{}
-			}
-
-			if subs != nil {
-				for _, chans := range subs {
-					for _, ch := range chans {
-						close(ch)
-					}
-				}
-			}
+			m.destroy()
 		}()
 	}
 
-	return
+	return m, nil
 }
 
-func (m *mqtt) onConnect(server string, code byte, err error) {
-	m.Lock()
-	defer m.Unlock()
+func (m *mqtt) isCancelled() bool {
+	if m.ctx != nil {
+		select {
+		case <-m.ctx.Done():
+			return true
+		default:
+		}
+	}
+	return false
+}
 
-	if code != libmqtt.CodeSuccess && err == nil {
-		err = fmt.Errorf("error code %d", int(code))
+type Err string
+
+func (e Err) Error() string { return string(e) }
+
+const (
+	ErrIsAlreadyRunning Err = "already running"
+	ErrIsCancelled      Err = "cancelled"
+)
+
+func (m *mqtt) Start() (bool, error) {
+	m.Lock()
+	if m.errCh != nil {
+		m.Unlock()
+		return false, ErrIsAlreadyRunning
+	}
+	if m.isCancelled() {
+		m.Unlock()
+		return false, ErrIsCancelled
 	}
 
-	if m.initCh != nil {
-		if err != nil {
-			m.initCh <- err
-		} else {
-			close(m.initCh)
+	m.errCh = make(chan error)
+	if m.sub == nil {
+		m.sub = map[string][]chan []byte{}
+	}
+	if m.subRaw == nil {
+		m.subRaw = map[string][]chan *Packet{}
+	}
+
+	defer func() {
+		m.Lock()
+		stopCh := m.stopCh
+		m.stopCh = nil
+		m.errCh = nil
+		m.Unlock()
+		for _, ch := range stopCh {
+			close(ch)
+		}
+	}()
+	stopCh := make(chan struct{})
+	m.stopCh = append(m.stopCh, stopCh)
+	if m.ctx != nil {
+		go func(ctx context.Context) {
+			select {
+			case <-ctx.Done():
+				m.destroy()
+			case <-stopCh:
+				return
+			}
+		}(m.ctx)
+	}
+	m.Unlock()
+	m.client.Connect(m.onConnect)
+	err := <-m.errCh
+	return !m.isCancelled(), err
+}
+
+func (m *mqtt) destroy() {
+	stopCh := make(chan struct{})
+	m.Lock()
+	dsub := m.discoverSub
+	subs := m.sub
+	subRaw := m.subRaw
+	stateCh := m.deviceState
+	cl := m.client
+	if m.errCh != nil {
+		m.stopCh = append(m.stopCh, stopCh)
+	} else {
+		close(stopCh)
+	}
+	m.Unlock()
+
+	if cl != nil {
+		cl.Destroy(true)
+	}
+
+	m.Lock()
+	if m.errCh != nil {
+		close(m.errCh)
+		m.errCh = nil
+	}
+	m.discoverSub = []chan struct{}{}
+	m.sub = map[string][]chan []byte{}
+	m.subRaw = map[string][]chan *Packet{}
+	m.deviceState = nil
+	m.client = nil
+	m.Unlock()
+
+	if stateCh != nil {
+		close(stateCh)
+	}
+
+	for _, ch := range dsub {
+		close(ch)
+	}
+
+	if subRaw != nil {
+		for _, v := range subRaw {
+			for _, vv := range v {
+				func() {
+					defer func() {
+						_ = recover()
+					}()
+					close(vv)
+				}()
+			}
 		}
 	}
 
+	if subs != nil {
+		for _, chans := range subs {
+			for _, ch := range chans {
+				func() {
+					defer func() {
+						_ = recover()
+					}()
+					close(ch)
+				}()
+			}
+		}
+	}
+}
+
+func (m *mqtt) onConnect(server string, _code byte, err error) {
+	m.Lock()
+	defer m.Unlock()
+	code := Code(_code)
+
+	if code != libmqtt.CodeSuccess && err == nil {
+		err = code
+	}
+
 	if err != nil {
-		log.Printf("MQTT Connect Error: %s (%x) %v", server, code, err)
-		return
+		if m.errCh != nil {
+			m.errCh <- err
+			return
+		}
 	}
 
 	if m.deviceState != nil {


### PR DESCRIPTION
Add MQTT.Start() to better support detecting connection errors during runtime. Allows users to fail fast or control reconnection better

Breaking change: Start() must be called after New() to start transport